### PR TITLE
debounce collect

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -167,28 +167,33 @@ function csstransform (file) {
 
 // collect requires/imports
 function collect (files, file, rebundle) {
-  if (files) {
-    const l = files.length
-    let cnt = l
-    file = realpath(file)
-    preparedep(file)
-    for (let i = 0; i < l; i++) {
-      const index = i
-      resolve(files[i], { filename: file }, (err, result) => {
-        if (err) { throw err }
-        files[index] = result
-        if (!--cnt) {
-          for (let i = 0; i < l; i++) {
-            let resolved = realpath(files[i])
-            deps[file][resolved] = deps[resolved] || (deps[resolved] = {})
+  postcssify.collectTimer =   postcssify.collectTimer || {}
+  let timer =  postcssify.collectTimer[file]
+  if (timer) { clearTimeout(timer) }
+  postcssify.collectTimer[file] = setTimeout(() => {
+    if (files) {
+      const l = files.length
+      let cnt = l
+      file = realpath(file)
+      preparedep(file)
+      for (let i = 0; i < l; i++) {
+        const index = i
+        resolve(files[i], { filename: file }, (err, result) => {
+          if (err) { throw err }
+          files[index] = result
+          if (!--cnt) {
+            for (let i = 0; i < l; i++) {
+              let resolved = realpath(files[i])
+              deps[file][resolved] = deps[resolved] || (deps[resolved] = {})
+            }
+            debouncebundle(100)
           }
-          debouncebundle(100)
-        }
-      })
+        })
+      }
+    } else if (rebundle) {
+      debouncebundle(100)
     }
-  } else if (rebundle) {
-    debouncebundle(100)
-  }
+  }, 100)
 }
 
 // create or clear dep object


### PR DESCRIPTION
when we remove some `require('*.css')` from js files by leanify, collect method is called twice. first call has all require lines, second call is lean one (vier or vijf only).

because collect method resolves files async, first call overrides second and reverts to double css. when we debounce collect method 100ms, problem is solved.
